### PR TITLE
Change version of web.py to stable release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open('HISTORY.rst') as history_file:
     history = history_file.read().replace('.. :changelog:', '')
 
 requirements = [
-    'web.py==0.40-dev1',
+    'web.py==0.51',
     'rwlock==0.0.7',
     'promise==2.2.1',
     'requests==2.18.4',


### PR DESCRIPTION
I keep get this error when I try to run ``scripts/runserver.py``

```
sudo python3 scripts/runserver.py
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/web.py-0.40.dev1-py3.8.egg/web/utils.py", line 526, in take
    yield next(seq)
StopIteration

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "scripts/runserver.py", line 3, in <module>
    from multiav.webapi.py import app
  File "/usr/local/lib/python3.8/dist-packages/multiav-0.1.0-py3.8.egg/multiav/webapi.py", line 42, in <module>
    app = web.application(urls, globals())
  File "/usr/local/lib/python3.8/dist-packages/web.py-0.40.dev1-py3.8.egg/web/application.py", line 62, in __init__
    self.init_mapping(mapping)
  File "/usr/local/lib/python3.8/dist-packages/web.py-0.40.dev1-py3.8.egg/web/application.py", line 130, in init_mapping
    self.mapping = list(utils.group(mapping, 2))
  File "/usr/local/lib/python3.8/dist-packages/web.py-0.40.dev1-py3.8.egg/web/utils.py", line 531, in group
    x = list(take(seq, size))
RuntimeError: generator raised StopIteration
```

After I change the version of web.py to latest version, the script run smoothly.